### PR TITLE
update documentation for DynamoDB TTL support

### DIFF
--- a/doc_source/web-dynamodb-session.rst
+++ b/doc_source/web-dynamodb-session.rst
@@ -150,6 +150,14 @@ You can use the following configuration attributes in the :code:`providers` sect
     provider will automatically create the table if it doesn't exist. The default is :code:`true`. If this flag is
     set to :code:`false` and the table doesn't exist, an exception is thrown.
 
+*TTLAttributeName*
+    Optional :code:`string` attribute. The name of the TTL attribute for the table. This must be 
+    specified for session items to contain TTL-compatible data.
+
+*TTLExpiredSessionsSeconds*
+    Optional :code:`int` attribute. The minimum number of seconds after session expiration before sessions 
+    are eligible for TTL. By default this is 0. This value must be non-negative.
+
 
 .. _web-dynamodb-session-security:
 


### PR DESCRIPTION

*Description of changes:*
As of version `3.3.0.0`  of the Amazon DynamoDB Session State Provider for ASP.Net applications, support for the cleanup of expired sessions using DynamoDB's in-built TTL expiration of items has been added. Reference: https://github.com/aws/aws-dotnet-session-provider/commit/5ee13694fe7ea66089ceca7c31f547434aa59efa. This patch updates the documentation to reflect those changes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
